### PR TITLE
Svd pr

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,6 +1,10 @@
-name: Python package
+name: tox-check
 
-on: [push]
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
 
 jobs:
   build:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ classifiers =
 package_dir =
     = src
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.9
 install_requires =
     jax
     jaxlib

--- a/src/pfjax/particle_resamplers.py
+++ b/src/pfjax/particle_resamplers.py
@@ -70,7 +70,8 @@ def resample_mvn(key, x_particles_prev, logw):
     x_particles = random.multivariate_normal(key,
                                              mean=mvn_mean,
                                              cov=mvn_cov,
-                                             shape=(n_particles,))
+                                             shape=(n_particles,),
+                                             method="svd")
     return {
         "x_particles": unravel_fn(x_particles),
         "mvn_mean": mvn_mean,

--- a/src/pfjax/particle_resamplers.py
+++ b/src/pfjax/particle_resamplers.py
@@ -71,7 +71,7 @@ def resample_mvn(key, x_particles_prev, logw):
                                              mean=mvn_mean,
                                              cov=mvn_cov,
                                              shape=(n_particles,),
-                                             method="svd")
+                                             method="eigh")
     return {
         "x_particles": unravel_fn(x_particles),
         "mvn_mean": mvn_mean,

--- a/src/pfjax/sde.py
+++ b/src/pfjax/sde.py
@@ -200,7 +200,7 @@ class SDEModel(object):
         """
         valid_x = jax.vmap(self.is_valid, in_axes=(0, None))(x, theta)
         nan_x = jnp.any(jnp.isnan(x), axis=1)
-        return jnp.alltrue(valid_x, where=~nan_x) & jnp.alltrue(~nan_x)
+        return jnp.all(valid_x, where=~nan_x) & jnp.all(~nan_x)
 
     def state_lpdf(self, x_curr, x_prev, theta):
         """

--- a/src/pfjax/test/utils.py
+++ b/src/pfjax/test/utils.py
@@ -138,7 +138,7 @@ def resample_mvn_for(key, x_particles_prev, logw):
                                          mean=mu,
                                          cov=cov_mat,
                                          shape=(n_particles,),
-                                         method="svd")
+                                         method="eigh")
     ret_val = {"x_particles": samples.reshape(x_particles_prev.shape),
                "mvn_mean": mu,
                "mvn_cov": cov_mat}

--- a/src/pfjax/test/utils.py
+++ b/src/pfjax/test/utils.py
@@ -137,7 +137,8 @@ def resample_mvn_for(key, x_particles_prev, logw):
     samples = random.multivariate_normal(key,
                                          mean=mu,
                                          cov=cov_mat,
-                                         shape=(n_particles,))
+                                         shape=(n_particles,),
+                                         method="svd")
     ret_val = {"x_particles": samples.reshape(x_particles_prev.shape),
                "mvn_mean": mu,
                "mvn_cov": cov_mat}


### PR DESCRIPTION
- Updated github/workflow and setup to drop support for Python 3.7, 3.8 because Jax dropped support for them
- Updated mvn_resampler() to use svd decomposition
- Updated some syntax which is deprecated with newer Jax versions (i.e., jnp.alltrue -> jnp.all)